### PR TITLE
BUGFIX: handling negative values

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -53,7 +53,7 @@ def print_il_graphviz(name, il):
     else:
         # terminal
         if isinstance(il, long):
-            (signed, ) = struct.unpack("l", struct.pack("L", il))
+            (signed, ) = struct.unpack("l", struct.pack("l", il))
             il_str = "{: d} ({:#x})".format(signed, il)
         else:
             il_str = str(il)


### PR DESCRIPTION
Sometimes binja returns big numbers as negative values in LLIL_CONST .

The script failed then because L is used:
error: integer out of range for 'L' format code

Switching to 'l' fixes it
(does the whole unpack/pack still make sense then?)