### PR TITLE
uses recently fixed show_graph_report off BV

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -216,7 +216,7 @@ def graph_bnil(bv, addr):
 
     graph_ils(bv, g, head, function, addr)
 
-    g.show("Instruction Graph ({:#x})".format(addr))
+    bv.show_graph_report("Instruction Graph ({:#x})".format(addr), g)
 
 
 def match_condition(name, o):

--- a/plugin.json
+++ b/plugin.json
@@ -25,6 +25,6 @@
       "Windows": "",
       "Linux": ""
    },
-   "version": "1.2.1",
-   "minimumbinaryninjaversion": 0
+   "version": "1.2.2",
+   "minimumbinaryninjaversion": 2086
 }


### PR DESCRIPTION
also increments minor version number and adds a minimum required build for compatibility. If you end up doing a different version for the next actual release for the plugin manager it shouldn't really matter