### PR TITLE
Organize tool menu

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -372,11 +372,11 @@ def match_bnil(bv, addr):
 
 
 PluginCommand.register_for_address(
-    "BNIL Instruction Graph", "View BNIL Instruction Information", graph_bnil
+    "BNIL\\Instruction Graph", "View BNIL Instruction Information", graph_bnil
 )
 
 PluginCommand.register_for_address(
-    "BNIL Python Match Generator",
+    "BNIL\\Python Match Generator",
     "Generate a python function to match the selection instructions",
     match_bnil,
 )


### PR DESCRIPTION
Organize tool menu to prevent menu clutter for installs with multiple plugins enabled. 

Places `Instruction Graph` and  `Python Match Generator` in `BNIL` sub menu. 